### PR TITLE
refactor: deounce 훅 추가 및 필기저장 부분 적용 #14

### DIFF
--- a/front/components/customTextEditor/index.tsx
+++ b/front/components/customTextEditor/index.tsx
@@ -7,6 +7,8 @@ import { ContentEditableEvent } from 'react-contenteditable';
 import {
   TextEditorButton, TextEditorDiv, TextEditorDivWrapper, TextEditorHeaderDivWrapper,
 } from './styles';
+import useDebounce from '../../hooks/useDebounce';
+import DEBOUNCE_LIMIT_TIME from '../../config/constants';
 
 type Props = {
   finalTranscript: string;
@@ -18,10 +20,11 @@ type Props = {
 const CustomTextEditor: FunctionComponent<Props> = ({ finalTranscript, textNote, setTextNote }) => {
   // const [TextState, setTextState] = useState('');
   const TextStateRef = useRef<HTMLElement | null>(null);
+  const debounce = useDebounce(text => setTextNote(text), DEBOUNCE_LIMIT_TIME);
 
   const onChangeTextEditor = useCallback((e: ContentEditableEvent) => {
     // 텍스트 에디터 내부에 값이 변경될 때 마다 purify 진행한 값을 저장해주는 이벤트
-    setTextNote(DOMPurify.sanitize(e.target.value));
+    debounce(DOMPurify.sanitize(e.target.value));
   }, []);
 
   const onClickOperation = useCallback(

--- a/front/config/constants.ts
+++ b/front/config/constants.ts
@@ -1,0 +1,3 @@
+const DEBOUNCE_LIMIT_TIME = 1000;
+
+export default DEBOUNCE_LIMIT_TIME;

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useDebounce = <T extends any[]>(callback: (...args: T) => void, timeout: number) => {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  return (...args: T) => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      callback(...args);
+      timer.current = null;
+    }, timeout);
+  };
+};
+
+export default useDebounce;


### PR DESCRIPTION
## 목적
> 필기작성 시 불필요한 백엔드 호출을 막기 위한 debounce 적용

## 구현 기능
- [X] debounce 훅 생성
- [X] 필기 저장 부분에 debounce 적용

## check list
- [X] issue number를 브랜치 뒤에 추가 하였는가?
- [X] 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?

## 참고 자료
